### PR TITLE
Fix DS4 HID configuration for Orin device compatibility

### DIFF
--- a/config/tusb_config.h
+++ b/config/tusb_config.h
@@ -86,7 +86,7 @@ extern "C" {
 #endif
 
 //------------- CLASS -------------//
-#define CFG_TUD_HID 2
+#define CFG_TUD_HID 1
 #define CFG_TUD_CDC 0
 #define CFG_TUD_MSC 0
 #define CFG_TUD_MIDI 0

--- a/src/dualshock4.c
+++ b/src/dualshock4.c
@@ -5,7 +5,8 @@
 
 ds4_report_t default_ds4_report() {
   ds4_report_t report = {
-      .report_id = 0x01,
+      // Report ID is removed in DS4 report format. It's injected by the tud_hid_report() function.
+      // .report_id = 0x01,
       .left_stick_x = DS4_JOYSTICK_MID,
       .left_stick_y = DS4_JOYSTICK_MID,
       .right_stick_x = DS4_JOYSTICK_MID,
@@ -87,7 +88,8 @@ void convert_uni_to_ds4(const uni_gamepad_t gamepad, const uint8_t battery, ds4_
     return;
   }
 
-  ds4->report_id = 0x01;
+  // Report ID is removed in DS4 report format. It's injected by the tud_hid_report() function.
+  // ds4->report_id = 0x01;
   ds4->left_stick_x = (uint8_t)(gamepad.axis_x / 4 + 127);
   ds4->left_stick_y = (uint8_t)(gamepad.axis_y / 4 + 127);
   ds4->right_stick_x = (uint8_t)(gamepad.axis_rx / 4 + 127);

--- a/src/dualshock4.h
+++ b/src/dualshock4.h
@@ -79,7 +79,9 @@ typedef struct __attribute__((packed)) {
 
 // See for more details: https://www.psdevwiki.com/ps4/DS4-USB#Data_Format
 typedef struct __attribute__((packed)) {
-  uint8_t report_id;      // 0
+  // NOTE(oscarchoi): if report does not contain report_id, it is required to
+  // invoke tud_hid_report() with report_id which is not 0x00.
+  // uint8_t report_id;      // 0 (not used)
   uint8_t left_stick_x;   // 1
   uint8_t left_stick_y;   // 2
   uint8_t right_stick_x;  // 3
@@ -141,11 +143,11 @@ typedef struct __attribute__((packed)) {
   uint8_t unknown5[12];  // 52-63
 } ds4_report_t;
 
-_Static_assert(sizeof(ds4_report_t) == 64, "DS4 report size mismatch");
-_Static_assert(offsetof(ds4_report_t, temperature) == 12, "temperature byte must be at 12");
-_Static_assert(offsetof(ds4_report_t, tpad_counter) == 34,
-               "touch block must start at byte offset 34");
-_Static_assert(offsetof(ds4_report_t, unknown5) == 52, "unknown5 byte must be at 52");
+_Static_assert(sizeof(ds4_report_t) == 63, "DS4 report size mismatch");
+_Static_assert(offsetof(ds4_report_t, temperature) == 11, "temperature byte must be at 11");
+_Static_assert(offsetof(ds4_report_t, tpad_counter) == 33,
+               "touch block must start at byte offset 33");
+_Static_assert(offsetof(ds4_report_t, unknown5) == 51, "unknown5 byte must be at 51");
 
 ds4_report_t default_ds4_report();
 

--- a/src/usb_descriptors.h
+++ b/src/usb_descriptors.h
@@ -34,5 +34,7 @@ enum {
 };
 
 extern bool is_ds4_initialized;
+extern bool is_usb_mounted;
+extern bool report_in_flight;
 
 #endif /* USB_DESCRIPTORS_H_ */


### PR DESCRIPTION
Orin 장치에서 DS4 컨트롤러가 정상적으로 인식되지 않는 문제를 해결하기 위해 HID 설정을 최적화했습니다.

### 주요 변경사항
- **USB 초기화 로직 개선**: 마운트 상태 확인 및 리포트 전송 대기 시간 추가
- **HID 리포트 처리 개선**: `tud_hid_report()` 호출 시 명시적 report_id 사용
- **에러 처리 개선**: HID 리포트 응답에서 `max()` 대신 `min()` 사용하여 버퍼 오버플로우 방지

### 기술적 세부사항
- DS4 리포트 구조체 수정
- USB 마운트 대기 시간: 10ms 간격으로 변경
- 리포트 전송 완료 콜백 추가로 중복 전송 방지